### PR TITLE
主要タブに変更し、unicornのtimeoutを180に変更

### DIFF
--- a/app/models/article_statistic.rb
+++ b/app/models/article_statistic.rb
@@ -7,7 +7,7 @@ class ArticleStatistic < ApplicationRecord
     # 大元のサイト取得
 
     sleep(2)
-    url = 'https://news.yahoo.co.jp/topics/domestic'
+    url = 'https://news.yahoo.co.jp/topics/top-picks'
 
     doc = Nokogiri::HTML(URI.open(url))
 

--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -1,5 +1,5 @@
 $worker  = 2
-$timeout = 30
+$timeout = 180
 # 自分のアプリケーション名（currentがつくことに注意）
 $app_dir = '/var/www/what_interesting/current'
 $listen  = File.expand_path 'tmp/sockets/unicorn.sock', $app_dir


### PR DESCRIPTION
unicornのタイムアウトを無尽蔵に増やすのは良くないため、アプリ側の実行時間を減らす努力は今後も続けるべき